### PR TITLE
Backend: Add show_leaderboard_by_latest_submission field in challenge…

### DIFF
--- a/apps/challenges/serializers.py
+++ b/apps/challenges/serializers.py
@@ -113,6 +113,7 @@ class ChallengePhaseSplitSerializer(serializers.ModelSerializer):
             "challenge_phase_name",
             "dataset_split_name",
             "visibility",
+            "show_leaderboard_by_latest_submission"
         )
 
     def get_dataset_split_name(self, obj):

--- a/tests/unit/challenges/test_views.py
+++ b/tests/unit/challenges/test_views.py
@@ -2543,6 +2543,7 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
             visibility=ChallengePhaseSplit.PUBLIC,
             leaderboard_decimal_precision=2,
             is_leaderboard_order_descending=True,
+            show_leaderboard_by_latest_submission=False
         )
 
         self.challenge_phase_split_host = ChallengePhaseSplit.objects.create(
@@ -2550,6 +2551,7 @@ class BaseChallengePhaseSplitClass(BaseAPITestClass):
             challenge_phase=self.challenge_phase,
             leaderboard=self.leaderboard,
             visibility=ChallengePhaseSplit.HOST,
+            show_leaderboard_by_latest_submission=False
         )
 
     def tearDown(self):
@@ -2573,6 +2575,8 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split.id,
                 "dataset_split_name": self.dataset_split.name,
                 "visibility": self.challenge_phase_split.visibility,
+                "show_leaderboard_by_latest_submission":
+                    self.challenge_phase_split.show_leaderboard_by_latest_submission
             }
         ]
         self.client.force_authenticate(user=self.participant_user)
@@ -2608,6 +2612,8 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split.id,
                 "dataset_split_name": self.dataset_split.name,
                 "visibility": self.challenge_phase_split.visibility,
+                "show_leaderboard_by_latest_submission":
+                    self.challenge_phase_split.show_leaderboard_by_latest_submission
             },
             {
                 "id": self.challenge_phase_split_host.id,
@@ -2616,6 +2622,8 @@ class GetChallengePhaseSplitTest(BaseChallengePhaseSplitClass):
                 "dataset_split": self.dataset_split_host.id,
                 "dataset_split_name": self.dataset_split_host.name,
                 "visibility": self.challenge_phase_split_host.visibility,
+                "show_leaderboard_by_latest_submission":
+                    self.challenge_phase_split_host.show_leaderboard_by_latest_submission
             },
         ]
         self.client.force_authenticate(user=self.user)


### PR DESCRIPTION
… phase split serializer(#2568)

* Add `show_leaderboard_by_latest_submission` field in challenge phase split serializer

- Added field `show_leaderboard_by_latest_submission` in `ChallengePhaseSplitSerializer` in order to get this fields through `challenge_phase_split_list` from a particular object of phase splits.

* Updated tests

IMPORTANT NOTES (please read, then delete):

* The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor.".

* Please make sure to mention "#bugnum" somewhere in the description of the PR. This enables GitHub to link the PR to the corresponding bug.

Please also make sure to follow the [style rules](https://github.com/Cloud-CV/EvalAI/blob/master/.github/CONTRIBUTING.md#style-rules).
